### PR TITLE
Fix git remote parsing, allow for non git directories, updated linting, readme and hidden file_name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 env/
+venv/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -42,10 +42,14 @@ And keeps the access control in a centralised place that we already use.
   brew install flyctl
   ```
 
+  More information and installation instructions for other systems can be found
+  [in the 1password documentation](https://developer.1password.com/docs/cli/get-started/).
+
 - Allow 1Password to connect to 1Password-CLI by going to `Settings` -> `Developer` ->
   `Command-Line Interface (CLI)` and select `Connect with 1Password CLI`.
 
-- Sign into your 1Password and Fly account (if you wish to use the fly integration).
+- Sign into your 1Password desktop and if you wish to use the fly integration, also make sure
+  the CLI is authenticated.
 
 ### Installation
 

--- a/onepassword_secrets.py
+++ b/onepassword_secrets.py
@@ -3,6 +3,7 @@ import json
 import logging
 import re
 import subprocess
+import os
 import sys
 from datetime import datetime
 from io import StringIO
@@ -330,7 +331,7 @@ def create_1password_secrets(
             '--title',
             title,
             f'{ONE_PASSWORD_NOTES_CONTENT_FIELD_NAME}={raw_secrets}',
-            f'{ONE_PASSWORD_FILE_PATH_FIELD_NAME}={file_path}',
+            f'{ONE_PASSWORD_FILE_PATH_FIELD_NAME}[text]={file_path}',
             _make_last_edited_1password_custom_field_cli_argument(),
             '--format',
             'json',
@@ -452,8 +453,8 @@ def edit_1password_fly_secrets(app_id):
 
 
 def pull_local_secrets():
-    repository = get_git_repository_name_from_current_directory()
-    item_id = get_1password_env_file_item_id(f'repo:{repository}')
+    secret_note_label = get_secret_name_label_from_current_directory()
+    item_id = get_1password_env_file_item_id(secret_note_label)
 
     secrets = get_envs_from_1password(item_id)
 
@@ -474,8 +475,8 @@ def pull_local_secrets():
 
 
 def push_local_secrets():
-    repository_name = get_git_repository_name_from_current_directory()
-    item_id = get_1password_env_file_item_id(f'repo:{repository_name}')
+    secret_note_label = get_secret_name_label_from_current_directory()
+    item_id = get_1password_env_file_item_id(secret_note_label)
 
     env_file_name = get_filename_from_1password(item_id) or DEFAULT_ENV_FILE_NAME
 
@@ -487,11 +488,11 @@ def push_local_secrets():
 
 
 def create_local_secrets(secrets_file_path):
-    repository_name = get_git_repository_name_from_current_directory()
+    secret_note_label = get_secret_name_label_from_current_directory()
 
     raw_secrets = _get_file_contents(secrets_file_path, raise_if_not_found=True)
 
-    title = f'{secrets_file_path} local development repo:{repository_name}'
+    title = f'{secrets_file_path} local development {secret_note_label}'
 
     item = create_1password_secrets(
         file_path=secrets_file_path,
@@ -516,14 +517,10 @@ def create_local_secrets(secrets_file_path):
     print(item_url.replace('https://start.1password.com/', 'onepassword://'))
 
 
-def get_git_repository_name_from_current_directory():
-    """
-    Obtains the git repository name based on the current directory.
-    Requires git and a remote origin set.
-    TODO: In the future we should allow for use without remote origins, and even without git.
-          For example by inferring the name from the current directory.
-    """
+def _get_git_remote_origin_name() -> tuple[str | None, str | None]:
     GIT_REPOSITORY_REGEX = r'^(\w+)(:\/\/|@)([^\/:]+)[\/:]([^\/:]+)\/(.+).git$'
+
+    git_remote_origin_url = None
 
     try:
         git_remote_origin_url = subprocess.check_output([
@@ -532,8 +529,17 @@ def get_git_repository_name_from_current_directory():
             '--get',
             'remote.origin.url'
         ]).decode('utf-8')
-    except subprocess.CalledProcessError:
-        raise_error('Either not in a git repository or remote "origin" is not set')
+
+    except FileNotFoundError:
+        return ('git not in the PATH', None)
+
+    except subprocess.CalledProcessError as error:
+        exit_code, _command = error.args
+
+        if exit_code == 1:
+            return ('Either not in a git repository or remote "origin" is not set', None)
+
+        return ('Failed to retrieve the git remote "origin" url', None)
 
     regex_match = re.match(
         GIT_REPOSITORY_REGEX,
@@ -541,11 +547,32 @@ def get_git_repository_name_from_current_directory():
     )
 
     if regex_match is None:
-        raise_error('Could not get remote "origin" url from git repository')
+        return ('Failed to parse git remote "origin"', None)
 
-    repository_name = f'{regex_match.group(4)}/{regex_match.group(5)}'
+    return (
+        None,
+        f'{regex_match.group(4)}/{regex_match.group(5)}',
+    )
 
-    return repository_name
+
+def get_secret_name_label_from_current_directory() -> str:
+    """
+    Returns a predictable label for identifying the secrets based on the current directory.
+    If within a git repository with a remote named "origin" (and git is installed), it will output
+     something like: `repo:my-org/my-repo` or `repo:my-org/my-team/my-repo`.
+    Otherwise it will return the name of the directory as `local-dir:my-directory-name`.
+    """
+
+    error_message, git_remote_origin_name = _get_git_remote_origin_name()
+
+    if not error_message:
+        return f'repo:{git_remote_origin_name}'
+
+    directory_name = os.path.basename(os.getcwd())
+    label = f'local-dir:{directory_name}'
+
+    print(f'{error_message}, using the label based on the current directory: {label!r}')
+    return label
 
 
 def raise_error(message):
@@ -616,5 +643,4 @@ def main():
 
 
 if __name__ == '__main__':
-    # main()
-    print(get_git_repository_name_from_current_directory())
+    main()

--- a/onepassword_secrets.py
+++ b/onepassword_secrets.py
@@ -1,9 +1,9 @@
 import argparse
 import json
 import logging
+import os
 import re
 import subprocess
-import os
 import sys
 from datetime import datetime
 from io import StringIO

--- a/onepassword_secrets.py
+++ b/onepassword_secrets.py
@@ -517,7 +517,13 @@ def create_local_secrets(secrets_file_path):
 
 
 def get_git_repository_name_from_current_directory():
-    GIT_REPOSITORY_REGEX = r'^(https|git)(:\/\/|@)([^\/:]+)[\/:]([^\/:]+)\/(.+).git$'
+    """
+    Obtains the git repository name based on the current directory.
+    Requires git and a remote origin set.
+    TODO: In the future we should allow for use without remote origins, and even without git.
+          For example by inferring the name from the current directory.
+    """
+    GIT_REPOSITORY_REGEX = r'^(\w+)(:\/\/|@)([^\/:]+)[\/:]([^\/:]+)\/(.+).git$'
 
     try:
         git_remote_origin_url = subprocess.check_output([
@@ -610,4 +616,5 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    # main()
+    print(get_git_repository_name_from_current_directory())

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 
-flake8==6.0.0
-isort==5.12.0
-pycodestyle==2.10.0
+flake8==7.0.0
+isort==5.13.2
+pycodestyle==2.11.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,13 +1,13 @@
 [flake8]
 max-line-length = 100
-exclude = .git,__pycache__,env,build
+exclude = .git,__pycache__,env,venv,build
 
 [pycodestyle]
 max-line-length = 100
-exclude = .git,__pycache__,env,build
+exclude = .git,__pycache__,env,venv,build
 
 [isort]
 line_length = 100
 include_trailing_comma = True
 multi_line_output = 5
-skip = .git,__pycache__,env,build
+skip = .git,__pycache__,env,venv,build


### PR DESCRIPTION
1. Closes #16 - allow for more generic git url parsing.
2. Allow using 1password-secrets outside git repos or git repos without a remote named "origin" - or even if git is not installed.
3. Had to update the dev deps as I faced an odd bug in pycodestyle:
    ```
    pycodestyle .
    ./onepassword_secrets.py:412:51: E231 missing whitespace after ':'
    ./onepassword_secrets.py:429:51: E231 missing whitespace after ':'
    ./onepassword_secrets.py:456:52: E231 missing whitespace after ':'
    ./onepassword_secrets.py:478:52: E231 missing whitespace after ':'
    ./onepassword_secrets.py:494:57: E231 missing whitespace after ':'
    ```
4. Updated readme
5. Fixed note creation that would set file_name as a password and not as a text field (only has UI implications).