### PR TITLE
Add --vault and --remote switches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ lint: ## Ensure code properly formatted
 	isort . --check
 
 format: ## Format the code according to the standards
-	autopep8 --recursive --in-place .
+	autopep8 --exclude .venv --exclude venv --recursive --in-place .
 	flake8 --format .
 	isort .
 

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ The remote name can be changed with the `--remote` switch if you use a different
 By default it syncs to `./.env` file, this can overridden with a `file_name` field in 1password
 containing the desired relative file path.
 
-Also by default it uses the `Private` 1Password vault.  You can select another
-vault with the `--vault` switch.
+By default it searches items across 1password vaults. Restrict the search to a single vault with the
+`--vault` switch.
 
 - To bootstrap a 1Password secret matching the current repo/directory, run:
   `1password-secrets local create ./env`  
@@ -103,8 +103,8 @@ vault with the `--vault` switch.
 Make sure you have a Secure Note in 1Password with `fly:<fly-app-name>` in the title. `fly-app-name`
 is the name of your fly application.
 
-As with `Local` secrets above, you can select a 1Password vault to use with the
-`--vault` option
+As with `Local` secrets above, you can specify a single 1Password vault by name or id with the
+`--vault` option.
 
 - To import secrets to fly, run:
   `1password-secrets fly import <fly-app-name>`

--- a/README.md
+++ b/README.md
@@ -78,8 +78,12 @@ instructions.
 1password-secrets will allow you to `create`, `pull` and `push` secrets to a 1password secure note
 with `repo:<owner>/<repo>` or `local:<dir-basename>` in its name. `repo` is used when within a valid
 git repository with remote "origin" set.
+
 By default it syncs to `./.env` file, this can overridden with a `file_name` field in 1password
 containing the desired relative file path.
+
+Also by default it uses the `Private` 1Password vault.  You can select another
+vault with the `--vault` switch.
 
 - To bootstrap a 1Password secret matching the current repo/directory, run:
   `1password-secrets local create ./env`  
@@ -95,6 +99,9 @@ containing the desired relative file path.
 
 Make sure you have a Secure Note in 1Password with `fly:<fly-app-name>` in the title. `fly-app-name`
 is the name of your fly application.
+
+As with `Local` secrets above, you can select a 1Password vault to use with the
+`--vault` option
 
 - To import secrets to fly, run:
   `1password-secrets fly import <fly-app-name>`

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ instructions.
 with `repo:<owner>/<repo>` or `local:<dir-basename>` in its name. `repo` is used when within a valid
 git repository with remote "origin" set.
 
+The remote name can be changed with the `--remote` switch if you use a different remote
+(e.g. `upstream`)
+
 By default it syncs to `./.env` file, this can overridden with a `file_name` field in 1password
 containing the desired relative file path.
 

--- a/onepassword_secrets.py
+++ b/onepassword_secrets.py
@@ -76,7 +76,8 @@ def get_1password_env_file_item_id(title_substring, vault=None):
     if len(item_ids) > 1:
         raise_error(
             f'Found {len(item_ids)} 1password secure notes with a name containing '
-            f'{title_substring!r}, expected one'
+            f'{title_substring!r}, expected one. '
+            'Rename or use different 1password vaults in combination with the `--vault` option.'
         )
 
     return item_ids[0]
@@ -313,21 +314,18 @@ def _prompt_secret_diff(previous_raw_secrets, new_raw_secrets):
         raise_error('Aborted by user')
 
 
-def _run_1password_command(*args, vault=None, json_output=True):
-    command_args = [
-        'op',
-        *args,
-        *(
-            tuple()
-            if vault is None else
-            ('--vault', vault)
-        ),
-        *(
-            ('--format', 'json')
-            if json_output else
-            tuple()
-        ),
-    ]
+def _run_1password_command(
+    *args,
+    vault=None,
+    json_output=True
+):
+    command_args = ['op', *args]
+
+    if vault is not None:
+        command_args.extend(['--vault', vault])
+
+    if json_output:
+        command_args.extend(['--format', 'json'])
 
     logger.debug(
         'Running command: {}'.format(

--- a/onepassword_secrets.py
+++ b/onepassword_secrets.py
@@ -443,7 +443,7 @@ def import_1password_secrets_to_fly(app_id, vault=ONE_PASSWORD_VAULT):
 def edit_1password_fly_secrets(app_id, vault=ONE_PASSWORD_VAULT):
     item_id = get_1password_env_file_item_id(f'fly:{app_id}', vault=vault)
 
-    current_raw_secrets = get_envs_from_1password(item_id)
+    current_raw_secrets = get_envs_from_1password(item_id, vault=vault)
 
     with NamedTemporaryFile('w+') as file:
         file.writelines(current_raw_secrets)

--- a/onepassword_secrets.py
+++ b/onepassword_secrets.py
@@ -18,7 +18,6 @@ DEFAULT_ENV_FILE_NAME = '.env'
 ONE_PASSWORD_FILE_PATH_FIELD_NAME = 'file_name'
 ONE_PASSWORD_NOTES_CONTENT_FIELD_NAME = 'notesPlain'
 ONE_PASSWORD_SECURE_NOTE_CATEGORY = 'Secure Note'
-ONE_PASSWORD_VAULT = 'Private'
 DEFAULT_REMOTE_NAME = 'origin'
 
 
@@ -38,6 +37,9 @@ def _setup_logger():
     logger = logging.getLogger()
     logger.setLevel(logging.INFO)
 
+    if logger.hasHandlers():
+        logger.handlers.clear()
+
     stdout_handler = logging.StreamHandler()
     stdout_handler.setFormatter(Formatter())
     logger.addHandler(stdout_handler)
@@ -48,20 +50,14 @@ def _setup_logger():
 logger = _setup_logger()
 
 
-def get_1password_env_file_item_id(title_substring, vault=ONE_PASSWORD_VAULT):
+def get_1password_env_file_item_id(title_substring, vault=None):
     secure_notes = json.loads(
-        subprocess.check_output(
-            [
-                'op',
-                'item',
-                'list',
-                '--categories',
-                ONE_PASSWORD_SECURE_NOTE_CATEGORY,
-                '--vault',
-                vault,
-                '--format',
-                'json',
-            ]
+        _run_1password_command(
+            'item',
+            'list',
+            '--categories',
+            ONE_PASSWORD_SECURE_NOTE_CATEGORY,
+            vault=vault,
         )
     )
 
@@ -73,8 +69,8 @@ def get_1password_env_file_item_id(title_substring, vault=ONE_PASSWORD_VAULT):
 
     if len(item_ids) == 0:
         raise_error(
-            f'No 1password secure note found with a name containing'
-            f' {title_substring!r} in vault {vault}'
+            f'No 1password secure note found with a name containing {title_substring!r} '
+            + (f'in vault {vault}' if vault else 'across all vaults')
         )
 
     if len(item_ids) > 1:
@@ -86,15 +82,13 @@ def get_1password_env_file_item_id(title_substring, vault=ONE_PASSWORD_VAULT):
     return item_ids[0]
 
 
-def get_item_from_1password(item_id, vault=ONE_PASSWORD_VAULT):
+def get_item_from_1password(item_id, vault=None):
     return json.loads(
-        subprocess.check_output(
-            ['op', 'item', 'get', item_id, '--format', 'json', '--vault', vault]
-        )
+        _run_1password_command('item', 'get', item_id, vault=vault)
     )
 
 
-def get_envs_from_1password(item_id, vault=ONE_PASSWORD_VAULT):
+def get_envs_from_1password(item_id, vault=None):
     item = get_item_from_1password(item_id, vault=vault)
 
     result = first(
@@ -108,7 +102,7 @@ def get_envs_from_1password(item_id, vault=ONE_PASSWORD_VAULT):
     return result
 
 
-def get_filename_from_1password(item_id, vault=ONE_PASSWORD_VAULT):
+def get_filename_from_1password(item_id, vault=None):
     item = get_item_from_1password(item_id, vault=vault)
 
     result = first(
@@ -319,17 +313,48 @@ def _prompt_secret_diff(previous_raw_secrets, new_raw_secrets):
         raise_error('Aborted by user')
 
 
+def _run_1password_command(*args, vault=None, json_output=True):
+    command_args = [
+        'op',
+        *args,
+        *(
+            tuple()
+            if vault is None else
+            ('--vault', vault)
+        ),
+        *(
+            ('--format', 'json')
+            if json_output else
+            tuple()
+        ),
+    ]
+
+    logger.debug(
+        'Running command: {}'.format(
+            ' '.join(
+                (
+                    f'"{arg}"'
+                    if ' ' in arg
+                    else arg
+                )
+                for arg in command_args
+            )
+        )
+    )
+
+    return subprocess.check_output(command_args)
+
+
 def create_1password_secrets(
     file_path,
     raw_secrets,
     title,
-    vault=ONE_PASSWORD_VAULT
+    vault=None
 ):
     logger.debug('Creating 1password secret note')
 
     return json.loads(
-        subprocess.check_output([
-            'op',
+        _run_1password_command(
             'item',
             'create',
             '--category',
@@ -339,11 +364,8 @@ def create_1password_secrets(
             f'{ONE_PASSWORD_NOTES_CONTENT_FIELD_NAME}={raw_secrets}',
             f'{ONE_PASSWORD_FILE_PATH_FIELD_NAME}[text]={file_path}',
             _make_last_edited_1password_custom_field_cli_argument(),
-            '--format',
-            'json',
-            '--vault',
-            vault
-        ])
+            vault=vault,
+        )
     )
 
 
@@ -351,7 +373,7 @@ def update_1password_secrets(
     item_id,
     new_raw_secrets,
     previous_raw_secrets=None,
-    vault=ONE_PASSWORD_VAULT
+    vault=None
 ):
     if previous_raw_secrets is None:
         previous_raw_secrets = get_envs_from_1password(item_id)
@@ -362,31 +384,25 @@ def update_1password_secrets(
     )
 
     logger.debug(f'Updating 1password secret note content for item {item_id!r}')
-    subprocess.check_output([
-        'op',
+    _run_1password_command(
         'item',
         'edit',
         item_id,
         f'notesPlain={new_raw_secrets}',
         _make_last_edited_1password_custom_field_cli_argument(),
-        '--vault',
-        vault
-    ])
+        vault=vault,
+    )
 
 
-def update_1password_custom_field(item_id, field, value, vault=ONE_PASSWORD_VAULT):
+def update_1password_custom_field(item_id, field, value, vault=None):
     logger.debug(f'Updating 1password custom field for item {item_id!r}')
-    subprocess.check_output([
-        'op',
+    _run_1password_command(
         'item',
         'edit',
         item_id,
         _make_1password_custom_field_cli_argument(field, value),
-        '--format',
-        'json',
-        '--vault',
-        vault
-    ])
+        vault=vault,
+    )
 
 
 def _make_1password_custom_field_cli_argument(field_name, value):
@@ -422,7 +438,7 @@ def get_secrets_from_envs(input: str):
     return secrets
 
 
-def import_1password_secrets_to_fly(app_id, vault=ONE_PASSWORD_VAULT):
+def import_1password_secrets_to_fly(app_id, vault=None):
 
     item_id = get_1password_env_file_item_id(f'fly:{app_id}', vault=vault)
 
@@ -441,10 +457,10 @@ def import_1password_secrets_to_fly(app_id, vault=ONE_PASSWORD_VAULT):
     )
 
 
-def edit_1password_fly_secrets(app_id, vault=ONE_PASSWORD_VAULT):
+def edit_1password_fly_secrets(app_id, vault=None):
     item_id = get_1password_env_file_item_id(f'fly:{app_id}', vault=vault)
 
-    current_raw_secrets = get_envs_from_1password(item_id,vault=vault)
+    current_raw_secrets = get_envs_from_1password(item_id, vault=vault)
 
     with NamedTemporaryFile('w+') as file:
         file.writelines(current_raw_secrets)
@@ -468,7 +484,7 @@ def edit_1password_fly_secrets(app_id, vault=ONE_PASSWORD_VAULT):
         import_1password_secrets_to_fly(app_id, vault=vault)
 
 
-def pull_local_secrets(remote=DEFAULT_REMOTE_NAME, vault=ONE_PASSWORD_VAULT):
+def pull_local_secrets(remote=DEFAULT_REMOTE_NAME, vault=None):
     secret_note_label = get_secret_name_label_from_current_directory(remote=remote)
     item_id = get_1password_env_file_item_id(secret_note_label, vault=vault)
 
@@ -490,7 +506,7 @@ def pull_local_secrets(remote=DEFAULT_REMOTE_NAME, vault=ONE_PASSWORD_VAULT):
     print(f'Successfully updated {env_file_name} from 1password')
 
 
-def push_local_secrets(remote=DEFAULT_REMOTE_NAME, vault=ONE_PASSWORD_VAULT):
+def push_local_secrets(remote=DEFAULT_REMOTE_NAME, vault=None):
     secret_note_label = get_secret_name_label_from_current_directory(remote=remote)
     item_id = get_1password_env_file_item_id(secret_note_label, vault=vault)
 
@@ -503,7 +519,7 @@ def push_local_secrets(remote=DEFAULT_REMOTE_NAME, vault=ONE_PASSWORD_VAULT):
     print(f'Successfully pushed secrets from {env_file_name} to 1password')
 
 
-def create_local_secrets(secrets_file_path, vault=ONE_PASSWORD_VAULT, remote=DEFAULT_REMOTE_NAME):
+def create_local_secrets(secrets_file_path, vault=None, remote=DEFAULT_REMOTE_NAME):
     secret_note_label = get_secret_name_label_from_current_directory(remote=remote)
 
     raw_secrets = _get_file_contents(secrets_file_path, raise_if_not_found=True)
@@ -517,27 +533,25 @@ def create_local_secrets(secrets_file_path, vault=ONE_PASSWORD_VAULT, remote=DEF
         vault=vault
     )
 
-    print(f'Item {title!r} created in 1password!\n')
-
     item_url = (
-        subprocess.check_output([
-            'op',
+        _run_1password_command(
             'item',
             'get',
             item["id"],
-            '--vault',
-            vault,
             '--share-link',
-        ])
+            vault=vault,
+            json_output=False,
+        )
         .decode('utf-8')
     ).strip()
 
+    print(f'Item {title!r} created in 1password!\n')
     print(item_url)
     print(item_url.replace('https://start.1password.com/', 'onepassword://'))
 
 
 def _get_git_remote_name(remote=DEFAULT_REMOTE_NAME) -> tuple[str | None, str | None]:
-    GIT_REPOSITORY_REGEX = r'^(\w+)(:\/\/|@)([^\/:]+)[\/:]([^\/:]+)\/(.+)(\.git)*$'
+    GIT_REPOSITORY_REGEX = r'^(\w+)(:\/\/|@)([^\/:]+)[\/:]([^\/:]+)\/(.+).git$'
 
     git_remote_url = None
 
@@ -547,7 +561,7 @@ def _get_git_remote_name(remote=DEFAULT_REMOTE_NAME) -> tuple[str | None, str | 
             'config',
             '--get',
             f'remote.{remote}.url'
-        ]).decode('utf-8')
+        ]).decode('utf-8').strip()
 
     except FileNotFoundError:
         return ('git not in the PATH', None)
@@ -556,9 +570,9 @@ def _get_git_remote_name(remote=DEFAULT_REMOTE_NAME) -> tuple[str | None, str | 
         exit_code, _command = error.args
 
         if exit_code == 1:
-            return (f'Either not in a git repository or remote "{remote}" is not set', None)
+            return (f'Either not in a git repository or remote {remote!r} is not set', None)
 
-        return (f'Failed to retrieve the git remote "{remote}" url', None)
+        return (f'Failed to retrieve the git remote {remote!r} url', None)
 
     regex_match = re.match(
         GIT_REPOSITORY_REGEX,
@@ -621,8 +635,11 @@ def main():
     parser.add_argument(
         '--vault',
         type=str,
-        default=ONE_PASSWORD_VAULT,
-        help='Specify on which vault to operate. Defaults to "Private"'
+        default=None,
+        help=(
+            'Specify a vault name or id to operate on. '
+            'Defaults to all vaults across the logged in account.'
+        )
     )
 
     parser.add_argument(
@@ -631,6 +648,7 @@ def main():
         default=DEFAULT_REMOTE_NAME,
         help='Construct secret name based on this git remote. Defaults to "origin"'
     )
+
     subparsers = parser.add_subparsers(dest='subcommand', required=True)
 
     fly_parser = subparsers.add_parser('fly', help='manage fly secrets')

--- a/onepassword_secrets.py
+++ b/onepassword_secrets.py
@@ -441,7 +441,7 @@ def import_1password_secrets_to_fly(app_id, vault=ONE_PASSWORD_VAULT):
 
 
 def edit_1password_fly_secrets(app_id, vault=ONE_PASSWORD_VAULT):
-    item_id = get_1password_env_file_item_id(f'fly:{app_id}')
+    item_id = get_1password_env_file_item_id(f'fly:{app_id}', vault=vault)
 
     current_raw_secrets = get_envs_from_1password(item_id)
 
@@ -467,9 +467,9 @@ def edit_1password_fly_secrets(app_id, vault=ONE_PASSWORD_VAULT):
         import_1password_secrets_to_fly(app_id, vault=vault)
 
 
-def pull_local_secrets(remote=DEFAULT_REMOTE_NAME):
+def pull_local_secrets(remote=DEFAULT_REMOTE_NAME, vault=ONE_PASSWORD_VAULT):
     secret_note_label = get_secret_name_label_from_current_directory(remote=remote)
-    item_id = get_1password_env_file_item_id(secret_note_label)
+    item_id = get_1password_env_file_item_id(secret_note_label, vault=vault)
 
     secrets = get_envs_from_1password(item_id)
 
@@ -491,7 +491,7 @@ def pull_local_secrets(remote=DEFAULT_REMOTE_NAME):
 
 def push_local_secrets(remote=DEFAULT_REMOTE_NAME, vault=ONE_PASSWORD_VAULT):
     secret_note_label = get_secret_name_label_from_current_directory(remote=remote)
-    item_id = get_1password_env_file_item_id(secret_note_label)
+    item_id = get_1password_env_file_item_id(secret_note_label, vault=vault)
 
     env_file_name = get_filename_from_1password(item_id) or DEFAULT_ENV_FILE_NAME
 

--- a/onepassword_secrets.py
+++ b/onepassword_secrets.py
@@ -422,9 +422,9 @@ def get_secrets_from_envs(input: str):
     return secrets
 
 
-def import_1password_secrets_to_fly(app_id, vault=ONE_PASSWORD_VAULT,
-                                    remote=DEFAULT_REMOTE_NAME):
-    item_id = get_1password_env_file_item_id(f'fly:{app_id}')
+def import_1password_secrets_to_fly(app_id, vault=ONE_PASSWORD_VAULT):
+
+    item_id = get_1password_env_file_item_id(f'fly:{app_id}', vault=vault)
 
     secrets = get_secrets_from_envs(get_envs_from_1password(item_id, vault=vault))
 

--- a/onepassword_secrets.py
+++ b/onepassword_secrets.py
@@ -472,9 +472,9 @@ def pull_local_secrets(remote=DEFAULT_REMOTE_NAME, vault=ONE_PASSWORD_VAULT):
     secret_note_label = get_secret_name_label_from_current_directory(remote=remote)
     item_id = get_1password_env_file_item_id(secret_note_label, vault=vault)
 
-    secrets = get_envs_from_1password(item_id)
+    secrets = get_envs_from_1password(item_id, vault=vault)
 
-    env_file_name = get_filename_from_1password(item_id) or DEFAULT_ENV_FILE_NAME
+    env_file_name = get_filename_from_1password(item_id, vault=vault) or DEFAULT_ENV_FILE_NAME
 
     previous_raw_secrets = _get_file_contents(env_file_name, raise_if_not_found=False)
 
@@ -664,9 +664,9 @@ def main():
 
         elif args.subcommand == 'local':
             if args.action == 'pull':
-                pull_local_secrets(remote=args.remote)
+                pull_local_secrets(remote=args.remote, vault=args.vault)
             elif args.action == 'push':
-                push_local_secrets(remote=args.remote)
+                push_local_secrets(remote=args.remote, vault=args.vault)
             elif args.action == 'create':
                 create_local_secrets(args.secrets_file_path, vault=args.vault, remote=args.remote)
 

--- a/onepassword_secrets.py
+++ b/onepassword_secrets.py
@@ -436,14 +436,15 @@ def import_1password_secrets_to_fly(app_id, vault=ONE_PASSWORD_VAULT):
     update_1password_custom_field(
         item_id,
         'last imported at',
-        now_formatted
+        now_formatted,
+        vault=vault
     )
 
 
 def edit_1password_fly_secrets(app_id, vault=ONE_PASSWORD_VAULT):
     item_id = get_1password_env_file_item_id(f'fly:{app_id}', vault=vault)
 
-    current_raw_secrets = get_envs_from_1password(item_id, vault=vault)
+    current_raw_secrets = get_envs_from_1password(item_id,vault=vault)
 
     with NamedTemporaryFile('w+') as file:
         file.writelines(current_raw_secrets)

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 
+autopep8
 flake8==7.0.0
 isort==5.13.2
 pycodestyle==2.11.1

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
-autopep8
+autopep8==2.1.1
 flake8==7.0.0
 isort==5.13.2
 pycodestyle==2.11.1

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requirements = (Path(__file__).parent / 'requirements.txt').read_text().split('\
 version = re.sub(
     r'^v',
     '',
-    os.getenv('VERSION', 'v0.0.1-development')
+    os.getenv('VERSION', 'v0.0.1-dev')
 )
 
 print(f'Publishing version {version}')


### PR DESCRIPTION
In my workflow I keep developer and production related secrets in a separate vault so I can share that vault with others.  I added a `--vault` switch to specify the vault.

I also don't use `origin` as the default remote as I have a GitHub organization that contains the "master" repository (the repo against which the devs open their PRs).  I added a `--remote` switch to give 1password-secrets a hint as to which remote it should use.
